### PR TITLE
Reordered architects

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -14,15 +14,10 @@ release:
     git checkout gh-pages
     for d in $(ls /tmp/site); do rm -rf $d; cp -r /tmp/site/$d .; git add $d; done
     git commit --allow-empty -m "${tag}"
-  commanders:
-    - yegor256
 architect:
-- yegor256
-- davvd
 - g4s8
+- yegor256
 merge:
-  commanders:
-    - yegor256
   script: |-
     pdd -f /dev/null
     bundle install


### PR DESCRIPTION
Slight cleanup of .rultor.yml file, davvd is no longer operational, g4s8 should be at the top of architects so he will get the requests for merging.
Commanders are not needed, it will take the architect for that.