### PR TITLE
For #339: assert-that template is not working correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 gem 'mustache', '1.0.5'
-gem 'nokogiri', '~>1.8'
+gem 'nokogiri', '1.7.2'
 gem 'rainbow', '~>2.2'
 gem 'rake', '12.0.0'
 gem 'redcarpet', '3.4.0'

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To make `rake` working you will need to install:
  - [bundler](https://bundler.io/)  (`gem install bundler`)
  - [maven](https://maven.apache.org/)
  
-To install all dependencies for rake run in project directory:
+To install all dependencies for `rake` run in project directory:
 ```sh
 bundle install
 mvn dependency:get -DgroupId=net.sf.saxon -DartifactId=Saxon-HE -Dversion=9.8.0-8

--- a/xsl-test/assertions.xsl
+++ b/xsl-test/assertions.xsl
@@ -15,12 +15,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:xs="http://www.w3.org/1999/xhtml"
-  version="2.0"
-  exclude-result-prefixes="xs">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/1999/xhtml" version="2.0" exclude-result-prefixes="xs">
   <xsl:template name="assert-that">
     <xsl:param name="ignore" select="'false'"/>
     <xsl:param name="message"/>

--- a/xsl-test/assertions.xsl
+++ b/xsl-test/assertions.xsl
@@ -22,14 +22,14 @@ SOFTWARE.
     <xsl:param name="expected"/>
     <xsl:param name="actual"/>
     <xsl:if test="$ignore = 'false'">
-      <xsl:if test="$expected != $actual">
+      <xsl:if test="not(deep-equal($expected, $actual))">
         <xsl:message terminate="yes">
           <xsl:text>FAILURE: </xsl:text>
           <xsl:value-of select="$message"/>
           <xsl:text> (actual "</xsl:text>
-          <xsl:value-of select="$actual_xml"/>
+          <xsl:value-of select="$actual"/>
           <xsl:text>" is not equal to expected "</xsl:text>
-          <xsl:value-of select="$expected_xml"/>
+          <xsl:value-of select="$expected"/>
           <xsl:text>")</xsl:text>
         </xsl:message>
       </xsl:if>

--- a/xsl-test/templates/project.xsl
+++ b/xsl-test/templates/project.xsl
@@ -23,7 +23,7 @@ SOFTWARE.
       <xsl:with-param name="message" select="'Fails to format project name'"/>
       <xsl:with-param name="expected">
         <span>
-          <code>
+          <code style="background-color:#daf1e0;">
             <a href="https://www.0crat.com/p/ABCDEFGHI" title="Project ABCDEFGHI">
               <xsl:text>ABCDEFGHI</xsl:text>
             </a>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,9 +146,11 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
-        <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
-          <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
-        </a>
+          <xsl:when test="inspector">
+            <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
+              <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
+            </a>
+          </xsl:when>
       </td>
     </tr>
   </xsl:template>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -63,9 +63,6 @@ SOFTWARE.
             <xsl:text>Title</xsl:text>
           </th>
           <th>
-            <xsl:text>Project</xsl:text>
-          </th>
-          <th>
             <xsl:text>Added</xsl:text>
           </th>
           <th>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,11 +146,16 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
+        <xsl:choose>
           <xsl:when test="inspector">
             <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
               <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
             </a>
           </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>-</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
       </td>
     </tr>
   </xsl:template>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,9 +146,9 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
-        <xsl:call-template name="user">
-          <xsl:with-param name="id" select="inspector"/>
-        </xsl:call-template>
+        <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
+          <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
+        </a>
       </td>
     </tr>
   </xsl:template>


### PR DESCRIPTION
For #339:
- Added `style` attribute to `code` element in `expected` parameter in `project.xsl`;
- Replaced `!=` operator by `not(deep-equal())` in `assertions.xsl` because received parameters are document fragments, not strings;
- Added `xmlns:xs` so it can be excluded in `assert-that` comparisons (`project.xsl` puts `xmlns:xs` in its elements);
- Corrected `actual` and `expected` variable names in failure message.