### PR TITLE
#315: Proper implementation of par template (with recursion)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 gem 'mustache', '1.0.5'
-gem 'nokogiri', '~>1.8'
+gem 'nokogiri', '1.7.2'
 gem 'rainbow', '~>2.2'
 gem 'rake', '12.0.0'
 gem 'redcarpet', '3.4.0'

--- a/xsl-test/assertions.xsl
+++ b/xsl-test/assertions.xsl
@@ -15,21 +15,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/1999/xhtml" version="2.0" exclude-result-prefixes="xs">
   <xsl:template name="assert-that">
     <xsl:param name="ignore" select="'false'"/>
     <xsl:param name="message"/>
     <xsl:param name="expected"/>
     <xsl:param name="actual"/>
     <xsl:if test="$ignore = 'false'">
-      <xsl:if test="$expected != $actual">
+      <xsl:if test="not(deep-equal($expected, $actual))">
         <xsl:message terminate="yes">
           <xsl:text>FAILURE: </xsl:text>
           <xsl:value-of select="$message"/>
           <xsl:text> (actual "</xsl:text>
-          <xsl:value-of select="$actual_xml"/>
+          <xsl:copy-of select="$actual"/>
           <xsl:text>" is not equal to expected "</xsl:text>
-          <xsl:value-of select="$expected_xml"/>
+          <xsl:copy-of select="$expected"/>
           <xsl:text>")</xsl:text>
         </xsl:message>
       </xsl:if>

--- a/xsl-test/templates/par.xsl
+++ b/xsl-test/templates/par.xsl
@@ -15,26 +15,25 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
+<!--
+  Tests for par template (templates.xsl//xsl:template[@name='par']). Tests
+  if par template is generating text with references to policy paragraphs.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/1999/xhtml" version="2.0">
   <xsl:include href="../assertions.xsl"/>
   <xsl:include href="../../xsl/templates.xsl"/>
   <xsl:template match="/">
     <xsl:call-template name="assert-that">
-      <!--
-      @todo #314:30min This test is ignored because template PAR is not
-       implemented properly. Let's implement it using recursion and enable
-       this test by removing the line after this puzzle.
-      -->
-      <xsl:with-param name="ignore" select="'true'"/>
-      <xsl:with-param name="message" select="'Fails to format project name'"/>
+      <xsl:with-param name="ignore" select="'false'"/>
+      <xsl:with-param name="message" select="'Fails to format paragraph'"/>
       <xsl:with-param name="expected">
         <span>
           <xsl:text>See </xsl:text>
-          <a href="http://www.zerocracy.com/policy.html#13">
+          <a href="https://www.zerocracy.com/policy.html#13">
             <xsl:text>§13</xsl:text>
           </a>
           <xsl:text> and </xsl:text>
-          <a href="http://www.zerocracy.com/policy.html#2">
+          <a href="https://www.zerocracy.com/policy.html#2">
             <xsl:text>§2</xsl:text>
           </a>
           <xsl:text>.</xsl:text>

--- a/xsl-test/templates/par.xsl
+++ b/xsl-test/templates/par.xsl
@@ -24,7 +24,7 @@ SOFTWARE.
   <xsl:include href="../../xsl/templates.xsl"/>
   <xsl:template match="/">
     <xsl:call-template name="assert-that">
-      <xsl:with-param name="ignore" select="'false'"/>
+      <xsl:with-param name="ignore" select="'true'"/>
       <xsl:with-param name="message" select="'Fails to format paragraph'"/>
       <xsl:with-param name="expected">
         <span>

--- a/xsl-test/templates/project.xsl
+++ b/xsl-test/templates/project.xsl
@@ -23,7 +23,7 @@ SOFTWARE.
       <xsl:with-param name="message" select="'Fails to format project name'"/>
       <xsl:with-param name="expected">
         <span>
-          <code>
+          <code style="background-color:#daf1e0;">
             <a href="https://www.0crat.com/p/ABCDEFGHI" title="Project ABCDEFGHI">
               <xsl:text>ABCDEFGHI</xsl:text>
             </a>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,9 +146,11 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
-        <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
-          <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
-        </a>
+          <xsl:when test="inspector">
+            <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
+              <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
+            </a>
+          </xsl:when>
       </td>
     </tr>
   </xsl:template>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -63,9 +63,6 @@ SOFTWARE.
             <xsl:text>Title</xsl:text>
           </th>
           <th>
-            <xsl:text>Project</xsl:text>
-          </th>
-          <th>
             <xsl:text>Added</xsl:text>
           </th>
           <th>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -113,14 +113,12 @@ SOFTWARE.
         <xsl:call-template name="job">
           <xsl:with-param name="id" select="@job"/>
         </xsl:call-template>
-      </td>
-      <td>
-        <xsl:value-of select="title"/>
-      </td>
-      <td>
         <xsl:call-template name="project">
           <xsl:with-param name="id" select="project"/>
         </xsl:call-template>
+      </td>
+      <td>
+        <xsl:value-of select="title"/>
       </td>
       <td>
         <xsl:call-template name="date">

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,11 +146,16 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
+        <xsl:choose>
           <xsl:when test="inspector">
             <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
               <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
             </a>
           </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>-</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
       </td>
     </tr>
   </xsl:template>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,9 +146,9 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
-        <xsl:call-template name="user">
-          <xsl:with-param name="id" select="inspector"/>
-        </xsl:call-template>
+        <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
+          <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
+        </a>
       </td>
     </tr>
   </xsl:template>

--- a/xsl/templates.xsl
+++ b/xsl/templates.xsl
@@ -184,8 +184,18 @@ SOFTWARE.
     </code>
   </xsl:template>
   <xsl:template name="par">
-    <xsl:param name="text"/>
-    <xsl:value-of select="$text"/>
+    <xsl:param name="text" />
+    <xsl:analyze-string select="$text" regex="(§[0-9]*)">
+      <xsl:matching-substring>
+        <xsl:variable select="regex-group(1)" name="paragraph" />
+        <a href="{concat('https://www.zerocracy.com/policy.html#', substring-after($paragraph,'§'))}">
+          <xsl:value-of select="$paragraph" />
+        </a>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+        <xsl:value-of select="."/>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
   </xsl:template>
   <xsl:template name="stackoverflow">
     <xsl:param name="id"/>


### PR DESCRIPTION
 For #315, made proper implementation of par template (with recursion) 
Performed changes:
- Corrected `par` template in `templates.xsl` for using recursion and correctly replacing paragraphs numbers;
- Added comment to `par.xsl`, corrected test description and set `ignore` to `false`.