### PR TITLE
Inspector image instead of login

### DIFF
--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -146,9 +146,9 @@ SOFTWARE.
         <xsl:value-of select="impediment"/>
       </td>
       <td>
-        <xsl:call-template name="user">
-          <xsl:with-param name="id" select="inspector"/>
-        </xsl:call-template>
+        <a href="https://www.0crat.com/u/{inspector}" title="@{inspector}">
+          <img src="https://socatar.com/github/{inspector}/90-90" style="width:30px;height:30px;border-radius:3px;vertical-align:middle;"/>
+        </a>
       </td>
     </tr>
   </xsl:template>


### PR DESCRIPTION
Replaced the QA reviewer text with image + link to github profile.
The real estate on agenda page is so small and using long nicks makes it even worse. An image is equally good (+ a link and  hover over) and takes much less space.