### PR TITLE
moving project to job column

### DIFF
--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -63,9 +63,6 @@ SOFTWARE.
             <xsl:text>Title</xsl:text>
           </th>
           <th>
-            <xsl:text>Project</xsl:text>
-          </th>
-          <th>
             <xsl:text>Added</xsl:text>
           </th>
           <th>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -113,14 +113,12 @@ SOFTWARE.
         <xsl:call-template name="job">
           <xsl:with-param name="id" select="@job"/>
         </xsl:call-template>
-      </td>
-      <td>
-        <xsl:value-of select="title"/>
-      </td>
-      <td>
         <xsl:call-template name="project">
           <xsl:with-param name="id" select="project"/>
         </xsl:call-template>
+      </td>
+      <td>
+        <xsl:value-of select="title"/>
       </td>
       <td>
         <xsl:call-template name="date">


### PR DESCRIPTION
Moved project ID to the job column, making more room for the title (similarly like it is on the board).

After changes (and if there are any titles), it would look like this:
![image](https://user-images.githubusercontent.com/105730/42159966-e89f6d66-7df5-11e8-873b-0c33eb8050d8.png)


BTW. I didn't move the title, but git decided to show the diff in such strange way.