### PR TITLE
#315: Implement par template with recursion

### DIFF
--- a/xsl-test/templates/par.xsl
+++ b/xsl-test/templates/par.xsl
@@ -24,7 +24,7 @@ SOFTWARE.
   <xsl:include href="../../xsl/templates.xsl"/>
   <xsl:template match="/">
     <xsl:call-template name="assert-that">
-      <xsl:with-param name="ignore" select="'true'"/>
+      <xsl:with-param name="ignore" select="'false'"/>
       <xsl:with-param name="message" select="'Fails to format paragraph'"/>
       <xsl:with-param name="expected">
         <span>

--- a/xsl/templates.xsl
+++ b/xsl/templates.xsl
@@ -186,11 +186,11 @@ SOFTWARE.
   </xsl:template>
   <xsl:template name="par">
     <xsl:param name="text"/>
-    <xsl:analyze-string select="$text" regex="(§[0-9]*)">
+    <xsl:analyze-string select="$text" regex="§([0-9]+)">
       <xsl:matching-substring>
         <xsl:variable select="regex-group(1)" name="paragraph"/>
-        <a href="{concat('https://www.zerocracy.com/policy.html#', substring-after($paragraph,'§'))}">
-          <xsl:value-of select="$paragraph"/>
+        <a href="{concat('https://www.zerocracy.com/policy.html#', $paragraph)}">
+          <xsl:value-of select="concat('§',$paragraph)"/>
         </a>
       </xsl:matching-substring>
       <xsl:non-matching-substring>

--- a/xsl/templates.xsl
+++ b/xsl/templates.xsl
@@ -185,12 +185,12 @@ SOFTWARE.
     </code>
   </xsl:template>
   <xsl:template name="par">
-    <xsl:param name="text" />
+    <xsl:param name="text"/>
     <xsl:analyze-string select="$text" regex="(§[0-9]*)">
       <xsl:matching-substring>
-        <xsl:variable select="regex-group(1)" name="paragraph" />
+        <xsl:variable select="regex-group(1)" name="paragraph"/>
         <a href="{concat('https://www.zerocracy.com/policy.html#', substring-after($paragraph,'§'))}">
-          <xsl:value-of select="$paragraph" />
+          <xsl:value-of select="$paragraph"/>
         </a>
       </xsl:matching-substring>
       <xsl:non-matching-substring>


### PR DESCRIPTION
For #315: Implementation of par templatewith recursion:
- Added documentation to `par.xml`
- Corrected message if test in `par.xml` fails
- Corrected urls to `https` in `par.xml`
- Removed `@todo` from `par.xml`
- Changed `par` template in `templates.xml` to use recursion