### PR TITLE
Add opacity to inspected agenda items

### DIFF
--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -111,6 +111,9 @@ SOFTWARE.
           <xsl:when test="inspector">
             <xsl:text>opacity:0.5;</xsl:text>
           </xsl:when>
+          <xsl:otherwise>
+            <xsl:text/>
+          </xsl:otherwise>
         </xsl:choose>
       </xsl:attribute>
       <td>

--- a/xsl/pmo/agenda.xsl
+++ b/xsl/pmo/agenda.xsl
@@ -106,6 +106,13 @@ SOFTWARE.
   </xsl:template>
   <xsl:template match="order">
     <tr>
+      <xsl:attribute name="style">
+        <xsl:choose>
+          <xsl:when test="inspector">
+            <xsl:text>opacity:0.5;</xsl:text>
+          </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
       <td>
         <xsl:call-template name="job">
           <xsl:with-param name="id" select="@job"/>


### PR DESCRIPTION
Added 50% opacity to agenda items that are under inspection (it usually requires less attention than other items).

Example:
![screenshot_2018-08-19 agenda 1](https://user-images.githubusercontent.com/105730/44311438-d28c8f00-a3e7-11e8-8e0b-d68e47445511.png)
