### PR TITLE
Add maxRevJobsInAgenda option

### DIFF
--- a/xml/pmo/options/-negative-rev-jobs.xml
+++ b/xml/pmo/options/-negative-rev-jobs.xml
@@ -16,11 +16,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <options version="0.25" updated="2016-12-29T09:03:21.684Z">
-  <maxJobsInAgenda>10</maxJobsInAgenda>
-  <maxRevJobsInAgenda>15</maxRevJobsInAgenda>
-  <notify>
-    <students>false</students>
-    <rfps>false</rfps>
-    <publish>true</publish>
-  </notify>
+  <maxRevJobsInAgenda>-10</maxRevJobsInAgenda>
 </options>

--- a/xsd/pmo/options.xsd
+++ b/xsd/pmo/options.xsd
@@ -34,6 +34,13 @@ SOFTWARE.
             </xs:restriction>
           </xs:simpleType>
         </xs:element>
+        <xs:element name="maxRevJobsInAgenda" minOccurs="0">
+          <xs:simpleType xml:base="xs:integer">
+            <xs:restriction base="xs:integer">
+              <xs:minInclusive value="1"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
         <xs:element name="notify" type="notify" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="updated" use="required" type="xs:dateTime"/>

--- a/xsl/pmo/options.xsl
+++ b/xsl/pmo/options.xsl
@@ -55,6 +55,16 @@ SOFTWARE.
             </td>
           </tr>
         </xsl:if>
+        <xsl:if test="maxRevJobsInAgenda">
+          <tr>
+            <td>
+              <xsl:text>Max REV jobs in agend</xsl:text>
+            </td>
+            <td>
+              <xsl:value-of select="maxRevJobsInAgenda"/>
+            </td>
+          </tr>
+        </xsl:if>
         <xsl:if test="notify">
           <tr>
             <td>


### PR DESCRIPTION
This is for https://github.com/zerocracy/farm/issues/1906

Adding maxRevJobsInAgenda option. Options file in Farm is validated against this schema. To add a new option there, this schema needs to have it.